### PR TITLE
Add Counted Lists and Counted Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,32 @@
 
 Rando is a new serialization format optimized for fast random access of unstructured data.
 
-|                                JSON | Rando                        | Comment                       |
-| ----------------------------------: | :--------------------------- | ----------------------------- |
-|                                 `0` | `+`                          | Zigzag Integers (val)         |
-|                                 `1` | `2+`                         | "                             |
-|                                `10` | `k+`                         | "                             |
-|                               `100` | `38+`                        | "                             |
-|                              `1000` | `vg+`                        | "                             |
-|                                `-1` | `1+`                         | "                             |
-|                               `-10` | `j+`                         | "                             |
-|                              `-100` | `37+`                        | "                             |
-|                             `-1000` | `vf+`                        | "                             |
-|               `0.03333333333333333` | `2\|u/`                      | Rational (zigzag(num),dem)    |
-|                           `3.14159` | `2ppu\|9.`                   | Decimal (base, exponent)      |
-|                              `true` | `!`                          | True                          |
-|                             `false` | `~`                          | False                         |
-|                              `null` | `?`                          | Null                          |
-|                                `""` | `$`                          | Empty String                  |
-|                          `"Banana"` | `Banana'`                    | B64 String                    |
-|                       `"Hi, World"` | `9$Hi, World`                | String                        |
-|                              `"🍌"` | `4$🍌`                       | UTF-8 String                  |
-|                           `[1,2,3]` | `6[2+4+6+`                   | Lists                         |
-|                     `[100,100,100]` | `6;1**38+`                   | Lists with Pointers (repeats) |
-|               `{"a":1,"b":2,"c":3}` | `c:a'2+b'4+c'6+`             | Maps                          |
-| `[{"name":"Alice"},{"name":"Bob"}]` | `l;8:8*Alice'9:name'Bob'`    | Maps and Lists with Pointers  |
+|                                JSON | Rando                        | Comment                                   |
+| ----------------------------------: | :--------------------------- | ----------------------------------------- |
+|                                 `0` | `+`                          | Zigzag Integers (val)                     |
+|                                 `1` | `2+`                         |                                           |
+|                                `10` | `k+`                         |                                           |
+|                               `100` | `38+`                        |                                           |
+|                              `1000` | `vg+`                        |                                           |
+|                                `-1` | `1+`                         |                                           |
+|                               `-10` | `j+`                         |                                           |
+|                              `-100` | `37+`                        |                                           |
+|                             `-1000` | `vf+`                        |                                           |
+|               `0.03333333333333333` | `2\|u/`                      | Rational ( zigzag(num) dem )              |
+|                           `3.14159` | `2ppu\|9.`                   | Decimal ( zigzag(base) zigzag(exponent) ) |
+|                              `true` | `!`                          | True                                      |
+|                             `false` | `~`                          | False                                     |
+|                              `null` | `?`                          | Null                                      |
+|                                `""` | `$`                          | Empty String                              |
+|                          `"Banana"` | `Banana'`                    | B64 String                                |
+|                       `"Hi, World"` | `9$Hi, World`                | String                                    |
+|                               `"🍌"` | `4$🍌`                        | UTF-8 String                              |
+|                           `[1,2,3]` | `6;2+4+6+`                   | Lists                                     |
+|                     `[100,100,100]` | `6;1**38+`                   | Lists with Pointers (repeats)             |
+|                           `[1,2,3]` | `6\|3;2+4+6+`                | Counted Lists                             |
+|               `{"a":1,"b":2,"c":3}` | `c:a'2+b'4+c'6+`             | Maps                                      |
+|               `{"a":1,"b":2,"c":3}` | `c\|3:a'b'c'2+4+6+`          | Counted Maps                              |
+| `[{"name":"Alice"},{"name":"Bob"}]` | `l\|2;8:8*Alice'9:name'Bob'` | Maps and Lists with Pointers              |
 
 Use Rando anywhere you might use JSON if the following are true:
 
@@ -52,30 +54,30 @@ npm i -S @creationix/rando
 Then import it as any module. The npm package also includes a `.d.ts` package for conveinence.
 
 ```js
-import { stringify, parse } from "@creationix/rando";
+import { stringify, parse } from "@creationix/rando"
 
 const sampleDoc = {
   person: {
-    name: "John Doe",
+    name: 'John Doe',
     age: 30,
     id: 12345,
-    "ai-generated": true,
+    'ai-generated': true,
   },
   list: [1, 2, 3, 4, 5],
   nested: {
-    key: "value",
+    key: 'value',
     nested: {
-      key: "value",
+      key: 'value',
     },
   },
-};
+}
 
-const encoded = stringify(sampleDoc);
-console.log(encoded);
-// 1w:person'H:name'8$John Doeage'Y+id'61O+c$ai-generated!list'a;2+4+6+8+a+6*n:b*d*nested'a:key'value'
+const encoded = stringify(sampleDoc)
+console.log(encoded)
+// 1B|3:person'list'11*H|4:name'age'id'c$ai-generated8$John DoeY+61O+!a;2+4+6+8+a+n|2:b*nested'6*a:key'value'
 
-const decoded = parse(encoded);
-console.log(decoded);
+const decoded = parse(encoded)
+console.log(decoded)
 // {
 //   person: [Getter],
 //   list: [Getter],
@@ -92,21 +94,23 @@ The decoded value in JavaScript is lazy parsed so it should be very fast even fo
 The basic types in JSON are supported along with automatically base64 encoded binary data.
 
 ```
-integer:   zigzag(number) `+`
-rational:  zigzag(numerator) `|` denominator `/`
-decimal:   zigzag(base) `|` zigzag(exponent) `.`
-pointer:   offset `*`
-reference: index `&`
-true:      `!`
-false:     `~`
-null:      `?`
-string:    len `$` utf-8-data
-bytes:     len `=` base64-data
-chain:     len `,` string-like-value*
-list:      len `;` value*
-map:       len `:` key/value*
-array:     len `#` count `#` width `;` array-index value*
-trie:      len `#` count `#` width `;` trie-index key/value*
+integer:      zigzag(number) `+`
+rational:     zigzag(numerator) `|` denominator `/`
+decimal:      zigzag(base) `|` zigzag(exponent) `.`
+pointer:      offset `*`
+reference:    index `&`
+true:         `!`
+false:        `~`
+null:         `?`
+string:       len `$` utf-8-data
+bytes:        len `=` base64-data
+chain:        len `,` string-like-value*
+list:         len `;` value*
+counted-list: len `|` count `;` value*
+map:          len `:` key/value*
+counted-map:  len `|` count `:` key* value*
+array:        len `|` count `#` width `;` array-index value*
+trie:         len `|` count `#` width `;` trie-index key* value*
 ```
 
 ### Pointers
@@ -132,14 +136,14 @@ For example, consider encoding this object:
 
 ```js
 {
-  method: "GET",
-  scheme: "https",
-  host: "example.com",
+  method: 'GET',
+  scheme: 'https',
+  host: 'example.com',
   port: 443,
-  path: "/",
+  path: '/',
   headers: [
-    ["accept", "application/json"],
-    ["user-agent", "Mozilla/5.0"],
+    ['accept', 'application/json'],
+    ['user-agent', 'Mozilla/5.0'],
   ],
 }
 ```
@@ -148,80 +152,31 @@ With this shared set of known values:
 
 ```js
 [
-  "method",
-  "GET",
-  "POST",
-  "PUT",
-  "DELETE",
-  "scheme",
-  "http",
-  "https",
-  "host",
-  "port",
-  "path",
-  "/",
+  'method',
+  'GET',
+  'POST',
+  'PUT',
+  'DELETE',
+  'scheme',
+  'http',
+  'https',
+  'host',
+  'port',
+  'path',
+  '/',
   80,
   443,
-  "headers",
-  "accept",
-  "user-agent",
-  ["accept", "application/json"],
-];
+  'headers',
+  'accept',
+  'user-agent',
+  ['accept', 'application/json'],
+]
 ```
 
 This yields the following rando encoding which is about 1/3 the size JSON would be.
 
 ```
-R:&1&5&7&8&b$example.com9&d&a&b&e&j;h&f;g&b$Mozilla/5.0
-```
-
-## Advanced Usage
-
-If it works for your use case, an optional `knownValues` option can be used on both `encode` and `decode`. This allows an encoder and decoder to have a known set of shared values. These can be integers, strings, or even objects or arrays. Any time the encoder finds these, it replaces them with references which are just a few bytes each!
-
-But make sure both the encoder and decoder have the exact same list in the same order.
-
-```js
-import { stringify, parse } from "@creationix/rando";
-
-// Some common values in an http response that
-// both sides know about (similar to HTTP2 HPACK)
-const opts = {
-  knownValues: [
-    "headers",
-    "body",
-    "Content-Length",
-    ["Content-Type", "application/json"],
-    ["Content-Type", "application/json; charset=utf-8"],
-    // Common status codes
-    "status",
-    200,
-    404,
-    308,
-  ],
-};
-
-const body = JSON.stringify({ hello: "world" });
-const httpResponse = {
-  status: 200,
-  headers: [
-    ["Content-Type", "application/json"],
-    ["Content-Length", body.length],
-  ],
-  body,
-};
-
-const encoded = stringify(httpResponse, opts);
-console.log(encoded);
-// A:5&6&&8;3&4;2&y+1&h${"hello":"world"}
-
-const decoded = parse(encoded, opts);
-console.log(decoded);
-// {
-//   status: [Getter],
-//   headers: [Getter],
-//   body: [Getter],
-// }
+R|6:&5&8&9&a&e&1&7&b$example.comd&b&j;h&f;g&b$Mozilla/5.0
 ```
 
 ### Pretty Printed Mode
@@ -268,23 +223,31 @@ console.log(JSON.stringify(fruit))
 
 // Compact Rando
 console.log(Rando.stringify(fruit))
-// 1f;o:E*red'L*e;Q*a$strawberrye:e*green'j*2;o*z:color'yellow'fruits'd;apple'banana'
+// 1l;o|2:I*M*red'e;U*a$strawberrye|2:g*k*green'2;q*z|2:color'fruits'yellow'd;apple'banana'
 
 // Pretty Rando
-console.log(Rando.stringify(fruit, { prettyPrint: true }))
-// 24;
-//  H:
-//   17* red'
-//   1d* n;
-//    1g*
+// 2p;
+//  M|2:
+//   1l*
+//   1o*
+//
+//   red'
+//   n;
+//    1u*
 //    a$strawberry
-//  q:
-//   p* green'
-//   u* 6;
-//    y*
-//  P:
-//   color' yellow'
-//   fruits' l;
+//  v|2:
+//   w*
+//   A*
+//
+//   green'
+//   6;
+//    F*
+//  U|2:
+//   color'
+//   fruits'
+//
+//   yellow'
+//   l;
 //    apple'
 //    banana'
 ```

--- a/src/rando.test.ts
+++ b/src/rando.test.ts
@@ -302,8 +302,8 @@ test('encode lists', () => {
 test('encode objects', () => {
   expect(stringify({})).toEqual(':')
   expect(stringify({ a: 0 })).toEqual("3:a'+")
-  expect(stringify({ a: 0, b: true })).toEqual("6:a'+b'!")
-  expect(stringify({ a: 0, b: true, c: {} })).toEqual("9:a'+b'!c':")
+  expect(stringify({ a: 0, b: true })).toEqual("6|2:a'b'+!")
+  expect(stringify({ a: 0, b: true, c: {} })).toEqual("9|3:a'b'c'+!:")
 })
 
 test('encode maps', () => {
@@ -316,7 +316,7 @@ test('encode maps', () => {
         [true, false],
       ]),
     ),
-  ).toEqual('6:2+4+!~')
+  ).toEqual('6|2:2+!4+~')
   expect(
     stringify(
       new Map<unknown, unknown>([
@@ -324,7 +324,7 @@ test('encode maps', () => {
         [[1, 2, 3], null],
       ]),
     ),
-  ).toEqual('b:;:6;2+4+6+?')
+  ).toEqual('b|2:;6;2+4+6+:?')
 })
 
 test('encode string chains', () => {
@@ -341,7 +341,7 @@ test('encode repeated values', () => {
   const l = new Array(35).fill(-2048)
   // This is big enough that __+ is duplicated once the pointer cost gets over 2 bytes
   // We only want to use pointers if they are actually smaller.
-  expect(stringify(l)).toEqual('17;__+_*Z*X*V*T*R*P*N*L*J*H*F*D*B*z*x*v*t*r*p*n*l*j*h*f*d*b*9*7*5*3*1**__+')
+  expect(stringify(l)).toEqual('17|z;__+_*Z*X*V*T*R*P*N*L*J*H*F*D*B*z*x*v*t*r*p*n*l*j*h*f*d*b*9*7*5*3*1**__+')
 })
 
 const fruit = [
@@ -351,7 +351,9 @@ const fruit = [
 ]
 
 test('encode known values', () => {
-  expect(stringify(fruit)).toEqual("1f;o:E*red'L*e;Q*a$strawberrye:e*green'j*2;o*z:color'yellow'fruits'd;apple'banana'")
+  expect(stringify(fruit)).toEqual(
+    "1l;o|2:I*M*red'e;U*a$strawberrye|2:g*k*green'2;q*z|2:color'fruits'yellow'd;apple'banana'",
+  )
   const options: EncodeOptions = {
     knownValues: [
       'color',
@@ -367,7 +369,7 @@ test('encode known values', () => {
       'strawberry',
     ],
   }
-  expect(stringify(fruit, options)).toEqual('B;b:&1&7&4;8&a&9:&4&7&2;8&b:&3&7&4;8&9&')
+  expect(stringify(fruit, options)).toEqual('H;b|2:&7&1&4;8&a&9|2:&7&4&2;8&b|2:&7&3&4;8&9&')
 })
 
 test('encode pretty-print', () => {
@@ -375,17 +377,19 @@ test('encode pretty-print', () => {
     prettyPrint: true,
   }
   expect(stringify({ int: 123, rational: 1 / 3, decimal: 1.23 }, options)).toEqual(
-    "G:\n int' 3S+\n rational' 2|3/\n decimal' 3S|3.",
+    "K|3:\n int'\n rational'\n decimal'\n\n 3S+\n 2|3/\n 3S|3.",
   )
-  expect(stringify({ bool: true, bool2: false, nil: null }, options)).toEqual("r:\n bool' !\n bool2' ~\n nil' ?")
+  expect(stringify({ bool: true, bool2: false, nil: null }, options)).toEqual(
+    "v|3:\n bool'\n bool2'\n nil'\n\n !\n ~\n ?",
+  )
   expect(stringify({ obj: {}, arr: [], chain: 'repeat/repeat/repeat' }, options)).toEqual(
-    "I:\n obj' :\n arr' ;\n chain' h,repeat'*7$/repeat",
+    "M|3:\n obj'\n arr'\n chain'\n\n :\n ;\n h,repeat'*7$/repeat",
   )
   expect(stringify({ string: 'Hello', bytes: new Uint8Array([1, 2, 3]) }, options)).toEqual(
-    "v:\n string' Hello'\n bytes' 4=AQID",
+    "y|2:\n string'\n bytes'\n\n Hello'\n 4=AQID",
   )
   expect(stringify(fruit, options)).toEqual(
-    "24;\n H:\n  17* red'\n  1d* n;\n   1g*\n   a$strawberry\n q:\n  p* green'\n  u* 6;\n   y*\n P:\n  color' yellow'\n  fruits' l;\n   apple'\n   banana'",
+    "2p;\n M|2:\n  1l*\n  1o*\n\n  red'\n  n;\n   1u*\n   a$strawberry\n v|2:\n  w*\n  A*\n\n  green'\n  6;\n   F*\n U|2:\n  color'\n  fruits'\n\n  yellow'\n  l;\n   apple'\n   banana'",
   )
 })
 
@@ -396,10 +400,10 @@ test('encode binary', () => {
   expect(encodeBinary(1234)).toEqual(new Uint8Array([197, 180, 2]))
   expect(encodeBinary(fruit)).toEqual(
     new Uint8Array([
-      236, 9, 141, 3, 244, 4, 57, 114, 101, 100, 228, 5, 236, 1, 180, 6, 169, 1, 115, 116, 114, 97, 119, 98, 101, 114,
-      114, 121, 221, 1, 212, 1, 89, 103, 114, 101, 101, 110, 164, 2, 44, 132, 3, 189, 4, 89, 99, 111, 108, 111, 114,
-      105, 121, 101, 108, 108, 111, 119, 105, 102, 114, 117, 105, 116, 115, 220, 1, 89, 97, 112, 112, 108, 101, 105, 98,
-      97, 110, 97, 110, 97,
+      156, 10, 136, 3, 45, 148, 5, 212, 5, 57, 114, 101, 100, 236, 1, 212, 6, 169, 1, 115, 116, 114, 97, 119, 98, 101,
+      114, 114, 121, 216, 1, 45, 228, 1, 164, 2, 89, 103, 114, 101, 101, 110, 44, 148, 3, 184, 4, 45, 89, 99, 111, 108,
+      111, 114, 105, 102, 114, 117, 105, 116, 115, 105, 121, 101, 108, 108, 111, 119, 220, 1, 89, 97, 112, 112, 108,
+      101, 105, 98, 97, 110, 97, 110, 97,
     ]),
   )
 })
@@ -671,7 +675,7 @@ test('encode README values', () => {
   expect(stringify('🍌')).toEqual('4$🍌')
   expect(stringify([1, 2, 3])).toEqual('6;2+4+6+')
   expect(stringify([100, 100, 100])).toEqual('6;1**38+')
-  expect(stringify({ a: 1, b: 2, c: 3 })).toEqual("c:a'2+b'4+c'6+")
+  expect(stringify({ a: 1, b: 2, c: 3 })).toEqual("c|3:a'b'c'2+4+6+")
   expect(stringify([{ name: 'Alice' }, { name: 'Bob' }])).toEqual("l;8:8*Alice'9:name'Bob'")
 
   const sampleDoc = {
@@ -692,7 +696,7 @@ test('encode README values', () => {
 
   const encoded1 = stringify(sampleDoc)
   expect(encoded1).toEqual(
-    "1w:person'H:name'8$John Doeage'Y+id'61O+c$ai-generated!list'a;2+4+6+8+a+6*n:b*d*nested'a:key'value'",
+    "1B|3:person'list'11*H|4:name'age'id'c$ai-generated8$John DoeY+61O+!a;2+4+6+8+a+n|2:b*nested'6*a:key'value'",
   )
 
   const decoded1 = parse(encoded1)
@@ -731,7 +735,7 @@ test('encode README values', () => {
     'user-agent',
     ['accept', 'application/json'],
   ]
-  expect(stringify(doc, { knownValues: known })).toEqual('R:&1&5&7&8&b$example.com9&d&a&b&e&j;h&f;g&b$Mozilla/5.0')
+  expect(stringify(doc, { knownValues: known })).toEqual('R|6:&5&8&9&a&e&1&7&b$example.comd&b&j;h&f;g&b$Mozilla/5.0')
 
   // Some common values in an http response that
   // both sides know about (similar to HTTP2 HPACK)
@@ -760,7 +764,7 @@ test('encode README values', () => {
     body,
   }
   const encoded = stringify(httpResponse, opts)
-  expect(encoded).toEqual('A:5&6&&8;3&4;2&y+1&h${"hello":"world"}')
+  expect(encoded).toEqual('A|3:5&&1&6&8;3&4;2&y+h${"hello":"world"}')
   const decoded = parse(encoded, opts)
   expect(decoded).toEqual(httpResponse)
 })

--- a/src/rando.ts
+++ b/src/rando.ts
@@ -24,7 +24,9 @@ const CHAIN = ',' // String, bytes, or regexp broken into pieces
 
 // Recursive Container Types
 const LIST = ';' // Multiple values in sequence
+// If SEP is present, val2 is count of items
 const MAP = ':' // Multiple key-value pairs
+// if SEP is present, it's keys first format and val2 is count of keys
 
 // Indexed containers:
 //   O(n) LIST become O(1) ARRAY
@@ -180,6 +182,8 @@ export function splitDecimal(val: number) {
 }
 
 export interface EncodeOptions {
+  mapCountedLimit?: number // The max count of map keys allowed before a length is encoded and keys are put first
+  listCountedLimit?: number // The max count of list items allowed before a length is encoded
   chainMinChars?: number
   chainSplitter?: RegExp
   prettyPrint?: boolean
@@ -191,9 +195,11 @@ export interface DecodeOptions {
   knownValues?: unknown[]
 }
 
-const defaults = {
+const defaults: Required<EncodeOptions> = {
   // Chain defaults were found by brute forcing all combinations on several datasets
   // But they can be adjusted for specific data for fine tuning.
+  mapCountedLimit: 1,
+  listCountedLimit: 10,
   chainMinChars: 7,
   chainSplitter: /([^a-zA-Z0-9-_]*[a-zA-Z0-9-_]+)/,
   prettyPrint: false,
@@ -327,6 +333,8 @@ export function stringify(rootVal: unknown, options: EncodeOptions = {}) {
 const base64Str = /^[a-zA-Z1-9-_][a-zA-Z0-9-_]{0,7}$/
 
 export function encode(rootVal: unknown, options: EncodeOptions = {}) {
+  const mapCountedLimit = options.mapCountedLimit ?? defaults.mapCountedLimit
+  const listCountedLimit = options.listCountedLimit ?? defaults.listCountedLimit
   const chainMinChars = options.chainMinChars ?? defaults.chainMinChars
   const chainSplitter = options.chainSplitter ?? defaults.chainSplitter
   const prettyPrint = options.prettyPrint ?? defaults.prettyPrint
@@ -516,7 +524,10 @@ export function encode(rootVal: unknown, options: EncodeOptions = {}) {
       encodeAny(val[i])
     }
     depth--
-    return pushHeader(LIST, offset - before, trim)
+    if (val.length <= listCountedLimit) {
+      return pushHeader(LIST, offset - before, trim)
+    }
+    return pushHeaderPair(LIST, offset - before, val.length, trim)
   }
 
   function encodeObject(val: object, trim = -1) {
@@ -527,15 +538,32 @@ export function encode(rootVal: unknown, options: EncodeOptions = {}) {
   }
 
   function encodeEntries(entries: [unknown, unknown][], trim = -1) {
-    depth++
     const before = offset
+    if (entries.length <= mapCountedLimit) {
+      depth++
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const [key, value] = entries[i]
+        encodeAny(value, 1)
+        encodeAny(key)
+      }
+      depth--
+      return pushHeader(MAP, offset - before, trim)
+    }
+    depth++
     for (let i = entries.length - 1; i >= 0; i--) {
-      const [key, value] = entries[i]
-      encodeAny(value, 1)
+      const [_, value] = entries[i]
+      encodeAny(value)
+    }
+    if (prettyPrint) {
+      pushRaw(new Uint8Array([10]))
+    }
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const [key] = entries[i]
       encodeAny(key)
     }
+
     depth--
-    return pushHeader(MAP, offset - before, trim)
+    return pushHeaderPair(MAP, offset - before, entries.length, trim)
   }
 
   function encodeAny(val: unknown, trim = -1): void {
@@ -639,6 +667,24 @@ export function decode(rando: Uint8Array, options: DecodeOptions = {}) {
       if (tag2 === DECIMAL.charCodeAt(0)) {
         const str = `${decodeZigZag(BigInt(val)).toString(10)}e${decodeZigZag(BigInt(val2)).toString(10)}`
         return [parseFloat(str), offset]
+      }
+      if (tag2 === MAP.charCodeAt(0)) {
+        let allStrings = true
+        const entries: [unknown, unknown][] = []
+        for (let i = 0; i < val2; i++) {
+          const [key, newOffset] = decodeAny(offset)
+          if (typeof key !== 'string') {
+            allStrings = false
+          }
+          entries[i] = [key, undefined]
+          offset = newOffset
+        }
+        for (let i = 0; i < val2; i++) {
+          const [value, newOffset] = decodeAny(offset)
+          entries[i][1] = value
+          offset = newOffset
+        }
+        return [allStrings ? Object.fromEntries(entries) : new Map(entries), offset]
       }
       throw new Error(`Invalid type following separator: ${String.fromCharCode(tag2)}`)
     }


### PR DESCRIPTION
To make random-access sparse access of lists and maps work better, we can add an optional count to the header.  Also for objects/maps, we should order the keys first followed by the values.  This makes the initial object load use a lot less blocks for large objects.